### PR TITLE
Gracefully fall back from tqdm_gui when matplotlib is missing

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -14,7 +14,15 @@ from tkinter import (
     messagebox,
 )
 
-from tqdm import tqdm_gui
+try:
+    from tqdm import tqdm_gui as progress_cls
+except ModuleNotFoundError:
+    from tqdm import tqdm as progress_cls
+else:  # ensure matplotlib is available for the GUI variant
+    try:  # pragma: no cover - simple import check
+        import matplotlib  # noqa: F401
+    except ModuleNotFoundError:  # pragma: no cover
+        from tqdm import tqdm as progress_cls
 
 from trey import rename_pdfs
 
@@ -34,7 +42,7 @@ def run_rename(input_path: str, dpi: int, pages: int, run_btn: Button | None = N
             dpi=dpi,
             pages=pages,
             jobs="auto",
-            progress_cls=tqdm_gui,
+            progress_cls=progress_cls,
         )
     except Exception as exc:  # pylint: disable=broad-except
         messagebox.showerror("Error", f"Failed to rename PDFs: {exc}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytesseract
 Pillow
 PyMuPDF
 tqdm
+matplotlib>=3.0


### PR DESCRIPTION
## Summary
- add matplotlib as an optional dependency
- fall back to `tqdm` when `tqdm_gui` cannot import matplotlib
- use common `progress_cls` in GUI renamer

## Testing
- `python - <<'PY'
from importlib import reload
import gui
reload(gui)
print('progress_cls:', gui.progress_cls.__name__)
for _ in gui.progress_cls(range(3)):
    pass
PY`
- `python - <<'PY'
from importlib import reload
import gui
reload(gui)
print('progress_cls:', gui.progress_cls.__name__)
try:
    for _ in gui.progress_cls(range(3)):
        pass
    print('progress bar ran')
except Exception as e:
    print('progress bar error:', e)
PY`
- `python gui.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6443d0c88333b86486557100f44e