### PR TITLE
Make single-job processing run without multiprocessing

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -41,7 +41,7 @@ def run_rename(input_path: str, dpi: int, pages: int, run_btn: Button | None = N
             out_zip,
             dpi=dpi,
             pages=pages,
-            jobs="auto",
+            jobs=1,
             progress_cls=progress_cls,
         )
     except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
## Summary
- Default `rename_pdfs` to a single job and run sequentially when only one worker is requested
- Pass `jobs=1` in GUI invocation to avoid spawning extra processes
- Adjust CLI job default to 1

## Testing
- `python -m py_compile trey.py gui.py`
- `python trey.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b8876288333b72cdd17aa784946